### PR TITLE
Feature/enable edit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ npm install react-leaflet-draw
 
 ## Getting started
 
-First you need to add this css style to your project:
-```js
+First, include leaflet-draw styles in your project
+```html
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
+```
+or by including
+```
+node_modules/leaflet-draw/dist/leaflet.draw.css
 ```
 
 You might need to add one more rule missing in the current css:
@@ -25,7 +29,7 @@ You might need to add one more rule missing in the current css:
 It's important to wrap EditControl component into FeatureGroup component from `react-leaflet`.
 The elements you draw will be added to this FeatureGroup layer, when you hit edit button only items in this layer will be edited.
 
-```js
+```jsx
 import { Map, TileLayer, FeatureGroup } from 'react-leaflet';
 import { EditControl } from "react-leaflet-draw"
 
@@ -48,3 +52,28 @@ const Component = () => (
 For more details on how to use this plugin check the [example](example/edit-control.js).
 
 You can pass more options on draw object, this informations can be found [here](https://github.com/Leaflet/Leaflet.draw#user-content-example-leafletdraw-config)
+
+## EditControl API
+
+#### Props
+
+|name            |type                        |description                                           |
+|----------------|----------------------------|------------------------------------------------------|
+|position        |string                      |control group position                                |
+|draw            |object <DrawOptions>        |enable/disable draw controls                          |
+|edit            |object <EditPolyOptions>    |enable/disable edit controls                          |
+|onEdited        |function                    |hook to leaflet-draw's `draw:edited` event            |
+|onCreated       |function                    |hook to leaflet-draw's `draw:created` event           |
+|onDeleted       |function                    |hook to leaflet-draw's `draw:deleted` event           |
+|onMounted       |function                    |hook to leaflet-draw's `draw:mounted` event           |
+|onEditStart     |function                    |hook to leaflet-draw's `draw:editstart` event         |
+|onEditStop      |function                    |hook to leaflet-draw's `draw:editstop` event          |
+|onDeleteStart   |function                    |hook to leaflet-draw's `draw:deletestart` event       |
+|onDeleteStop    |function                    |hook to leaflet-draw's `draw:deletestop` event        |
+
+#### Links to docs
+
+* [Control position options](http://leafletjs.com/reference.html#control-positions)
+* [DrawOptions](https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#drawoptions)
+* [EditPolyOptions](https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#editpolyoptions)
+* [Draw events](https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#l-draw-event)

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -21,7 +21,13 @@ export default class EditControl extends LayersControl {
     }, {}),
     onCreated: PropTypes.func,
     onMounted: PropTypes.func,
-    draw: PropTypes.object,
+    draw: PropTypes.shape({
+      polyline: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      polygon: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      rectangle: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      circle: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      marker: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+    }),
     edit: PropTypes.shape({
       edit: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
       remove: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -22,6 +22,12 @@ export default class EditControl extends LayersControl {
     onCreated: PropTypes.func,
     onMounted: PropTypes.func,
     draw: PropTypes.object,
+    edit: PropTypes.shape({
+      edit: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      remove: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      poly: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+      allowIntersection: PropTypes.bool,
+    }),
     position: PropTypes.oneOf([
       'topright',
       'topleft',
@@ -90,9 +96,10 @@ export default class EditControl extends LayersControl {
 
   updateDrawControls = () => {
     const { layerContainer } = this.context;
-    const { draw, position } = this.props;
+    const { draw, edit, position } = this.props;
     const options = {
       edit: {
+        ...edit,
         featureGroup: layerContainer
       }
     };


### PR DESCRIPTION
Added `edit` prop to `<EditControl />` in order to be able to hide "save" and "edit" buttons. Improved prop-type checks for `draw` prop as well. Updated readme.