### PR TITLE
Fixed issue where map context was undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   "homepage": "https://github.com/alex3165/react-leaflet-draw#readme",
   "peerDependencies": {
     "leaflet": "^1.0.3",
-    "react-leaflet": "^1.1.0",
+    "react-leaflet": "^1.1.6",
     "leaflet-draw": "^0.4.9",
-    "react": "^15.4.2"
+    "react": "^15.5.2",
+    "prop-types": "^15.5.2"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -1,8 +1,9 @@
-import { PropTypes } from 'react';
+import { PropTypes } from 'prop-types';
 import Draw from 'leaflet-draw'; // eslint-disable-line
 import isEqual from 'lodash.isequal';
 
 import { LayersControl } from 'react-leaflet';
+import { Map } from 'leaflet';
 
 const eventHandlers = {
   onEdited: 'draw:edited',
@@ -40,6 +41,14 @@ export default class EditControl extends LayersControl {
       'bottomright',
       'bottomleft'
     ])
+  };
+
+  static contextTypes = {
+    map: PropTypes.instanceOf(Map),
+    layerContainer: PropTypes.shape({
+      addLayer: PropTypes.func.isRequired,
+      removeLayer: PropTypes.func.isRequired
+    })
   };
 
   onDrawCreate = (e) => {


### PR DESCRIPTION
I was encountering an issue where `this.context.map` was not being populated by React. I'm still not 100% sure why this was happening, but it does coincide with the shift of 'PropTypes' from the core React library to a separate module. 

I am using `react@15.5.4` and `react-leaflet@1.1.7`.

To fix it made changes such that `PropTypes` is required from the `prop-types` library (which is included with react) and added an explicit `contextTypes` definition.