### PR TITLE
import PropTypes from prop-types lib instead of React

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "leaflet": "^1.0.3",
     "react-leaflet": "^1.1.0",
     "leaflet-draw": "^0.4.9",
+    "prop-types": "^15.5.5",
     "react": "^15.4.2"
   },
   "devDependencies": {
@@ -57,6 +58,7 @@
     "leaflet": "^1.0.3",
     "leaflet-draw": "^0.4.9",
     "lodash.isequal": "^4.4.0",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-leaflet": "^1.1.0",

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import Draw from 'leaflet-draw'; // eslint-disable-line
 import isEqual from 'lodash.isequal';
 


### PR DESCRIPTION
The library currently causes the following warning with React 15.5:
```
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```
![nayttokuva 2017-05-30 kello 16 47 11](https://cloud.githubusercontent.com/assets/2855908/26586434/cf2c9b24-4557-11e7-8902-bb838628a928.png)

This PR adds `prop-types` library to `peerDependencies` and imports `PropTypes` from `prop-types` instead of `React`.