### PR TITLE
Support React 16 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "leaflet": "^1.0.3",
     "react-leaflet": "^1.1.6",
     "leaflet-draw": "^0.4.9",
-    "react": "^15.5.2",
+    "react": "^15.0.0 || ^16.0.0",
     "prop-types": "^15.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This tracks [react-leaflet's approach](https://github.com/PaulLeCam/react-leaflet/blob/master/package.json#L50) by allowing anything in React 15 and anything in React 16.

Resolves #33 

