### PR TITLE
update react-leaflet to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install react-leaflet-draw
 
 First, include leaflet-draw styles in your project
 ```html
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css"/>
 ```
 or by including
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install react-leaflet-draw
 
 First, include leaflet-draw styles in your project
 ```html
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css"/>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.3/leaflet.draw.css"/>
 ```
 or by including
 ```

--- a/example/edit-control.js
+++ b/example/edit-control.js
@@ -25,13 +25,13 @@ export default class EditControlExample extends Component {
     let numEdited = 0;
     e.layers.eachLayer( (layer) => {
       numEdited += 1;
-    })
+    });
     console.log(`_onEdited: edited ${numEdited} layers`, e);
 
     this._onChange();
   }
 
-  _onCreated(e) {
+  _onCreated = (e) => {
     let type = e.layerType;
     let layer = e.layer;
     if (type === 'marker') {
@@ -47,11 +47,11 @@ export default class EditControlExample extends Component {
   }
 
   _onDeleted = (e) => {
-    
+
     let numDeleted = 0;
     e.layers.eachLayer( (layer) => {
       numDeleted += 1;
-    })
+    });
     console.log(`onDeleted: removed ${numDeleted} layers`, e);
 
     this._onChange();
@@ -112,7 +112,7 @@ export default class EditControlExample extends Component {
 
     let leafletGeoJSON = new L.GeoJSON(getGeoJson());
     let leafletFG = reactFGref.leafletElement;
-    
+
     leafletGeoJSON.eachLayer( (layer) => {
       leafletFG.addLayer(layer);
     });

--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
     <title>React-Leaflet-Draw example</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css"/>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css"/>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.3/leaflet.draw.css"/>
     <style>
       h1, h2, p {
         text-align: center;

--- a/example/index.html
+++ b/example/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>React-Leaflet-Draw example</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css"/>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0/leaflet.css"/>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css"/>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css"/>
     <style>
       h1, h2, p {
         text-align: center;

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   },
   "homepage": "https://github.com/alex3165/react-leaflet-draw#readme",
   "peerDependencies": {
-    "leaflet": "^1.0.3",
-    "react-leaflet": "^2.0.0-beta.1 || ^2.0.0",
-    "leaflet-draw": "^0.4.9 || ^1.0.2",
+    "leaflet": "^1.3.0",
+    "react-leaflet": "^2.0.0",
+    "leaflet-draw": "^1.0.2",
     "react": "^16.3.0",
     "prop-types": "^15.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash.isequal": "^4.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-leaflet": "^2.0.0-beta.1",
+    "react-leaflet": "^2.0.0",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.12.1"
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint": "^3.8.1",
     "eslint-plugin-react": "^6.4.1",
     "json-loader": "^0.5.4",
-    "leaflet": "^1.0.3",
+    "leaflet": "^1.3.1",
     "leaflet-draw": "^1.0.2",
     "lodash.isequal": "^4.4.0",
     "react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "leaflet": "^1.3.0",
     "react-leaflet": "^2.0.0",
-    "leaflet-draw": "^1.0.2",
+    "leaflet-draw": "^1.0.3",
     "react": "^16.3.0",
     "prop-types": "^15.5.2"
   },
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "^6.4.1",
     "json-loader": "^0.5.4",
     "leaflet": "^1.3.1",
-    "leaflet-draw": "^1.0.2",
+    "leaflet-draw": "^1.0.3",
     "lodash.isequal": "^4.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "homepage": "https://github.com/alex3165/react-leaflet-draw#readme",
   "peerDependencies": {
     "leaflet": "^1.0.3",
-    "react-leaflet": "^1.1.6",
-    "leaflet-draw": "^0.4.9",
-    "react": "^15.0.0 || ^16.0.0",
+    "react-leaflet": "^2.0.0-beta.1 || ^2.0.0",
+    "leaflet-draw": "^0.4.9 || ^1.0.2",
+    "react": "^16.3.0",
     "prop-types": "^15.5.2"
   },
   "devDependencies": {
@@ -56,11 +56,11 @@
     "eslint-plugin-react": "^6.4.1",
     "json-loader": "^0.5.4",
     "leaflet": "^1.0.3",
-    "leaflet-draw": "^0.4.9",
+    "leaflet-draw": "^1.0.2",
     "lodash.isequal": "^4.4.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "react-leaflet": "^1.1.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "react-leaflet": "^2.0.0-beta.1",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.12.1"
   }

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -61,11 +61,6 @@ class EditControl extends MapControl {
 
     let drawElement = createDrawElement(props);
 
-    for (const key in eventHandlers) {
-      if (this.props[key]) {
-        map.on(eventHandlers[key], this.props[key]);
-      }
-    }
     return drawElement;
   }
 
@@ -81,6 +76,12 @@ class EditControl extends MapControl {
     super.componentDidMount();
     const { map } = this.props.leaflet;
     const { onMounted } = this.props;
+
+    for (const key in eventHandlers) {
+      if (this.props[key]) {
+        map.on(eventHandlers[key], this.props[key]);
+      }
+    }
 
     map.on(leaflet.Draw.Event.CREATED, this.onDrawCreate);
 
@@ -111,15 +112,11 @@ class EditControl extends MapControl {
     const { map } = this.props.leaflet;
 
     this.leafletElement.remove(map);
-    this.updateDrawControls();
+    this.leafletElement = createDrawElement(this.props);
     this.leafletElement.addTo(map);
 
     return null;
   }
-
-  updateDrawControls = () => {
-    this.leafletElement = createDrawElement(this.props);
-  };
 }
 
 function createDrawElement(props) {
@@ -140,7 +137,7 @@ function createDrawElement(props) {
     options.position = position;
   }
 
-  return new leaflet.Control.Draw(options);
+  return new Control.Draw(options);
 }
 
 export default withLeaflet(EditControl);

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -57,11 +57,7 @@ class EditControl extends MapControl {
   };
 
   createLeafletElement(props) {
-    const { map } = props.leaflet;
-
-    let drawElement = createDrawElement(props);
-
-    return drawElement;
+    return createDrawElement(props);
   }
 
   onDrawCreate = (e) => {
@@ -130,7 +126,7 @@ function createDrawElement(props) {
   };
 
   if (draw) {
-    options.draw = draw;
+    options.draw = { ...draw };
   }
 
   if (position) {


### PR DESCRIPTION
This PR adds support for react-leaflet@2.0.0.

Also drops support for React < 16.3, the same as react-leaflet@2.

Updates peer dependency leaflet-draw to 1.0.2 .

I'm happy to change this, if there are problems with it.