### PR TITLE
Add "addOnCreate" option prop

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -53,7 +53,12 @@ class EditControl extends MapControl {
         addLayer: PropTypes.func.isRequired,
         removeLayer: PropTypes.func.isRequired
       })
-    })
+    }),
+    addOnCreate: PropTypes.bool
+  };
+
+  static defaultProps = {
+    addOnCreate: true
   };
 
   createLeafletElement(props) {
@@ -61,10 +66,12 @@ class EditControl extends MapControl {
   }
 
   onDrawCreate = (e) => {
-    const { onCreated } = this.props;
+    const { onCreated, addOnCreate } = this.props;
     const { layerContainer } = this.props.leaflet;
 
-    layerContainer.addLayer(e.layer);
+    if (addOnCreate) {
+      layerContainer.addLayer(e.layer);
+    }
     onCreated && onCreated(e);
   };
 


### PR DESCRIPTION
I had to make this change for my project because I'm processing the created data before attaching it to the feature group. By supporting `addOnCreate` option it looks intuitive, when set to false, to asynchronously handle the created data through `onCreated` event (even not adding the layer if the backend returns error).