### PR TITLE
Fixes #65 - Correct context for react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lodash-webpack-plugin": "^0.11.5"
   },
   "dependencies": {
-    "lodash-es": "^4.17.10"
+    "lodash-es": "^4.17.10",
+    "uglifyjs-webpack-plugin": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-draw",
-  "version": "0.19.0",
+  "version": "0.19.5",
   "description": "React component for leaflet-draw",
   "main": "dist/react-leaflet-draw.js",
   "module": "dist/esm/index.js",

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -75,7 +75,7 @@ class EditControl extends MapControl {
 
     for (const key in eventHandlers) {
       if (this.props[key]) {
-        map.on(eventHandlers[key], this.props[key]);
+        map.on(eventHandlers[key], (evt) => { this.props[key] && this.props[key](evt) });
       }
     }
 

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -73,10 +73,14 @@ class EditControl extends MapControl {
     const { map } = this.props.leaflet;
     const { onMounted } = this.props;
 
-    for (const key in eventHandlers) {
-      if (this.props[key]) {
-        map.on(eventHandlers[key], (evt) => { this.props[key] && this.props[key](evt) });
-      }
+    for (var key in eventHandlers) {
+      map.on(eventHandlers[key], (evt) => {
+        let handlers = Object.keys(eventHandlers).filter(handler => eventHandlers[handler] == evt.type)
+        if (handlers.length == 1) {
+          let handler = handlers[0]
+          this.props[handler] && this.props[handler](evt)
+        }
+      });
     }
 
     map.on(leaflet.Draw.Event.CREATED, this.onDrawCreate);


### PR DESCRIPTION
By creating an handler that's executed in the context of the event we can ensure that the state - when using React hooks - is correctly interpreted as the current state.