### PR TITLE
#69 Dynamically update the edit prop on EditControl

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -108,8 +108,9 @@ class EditControl extends MapControl {
     // If the props haven't changed, don't update
     if (
       isEqual(this.props.draw, prevProps.draw)
-      || isEqual(this.props.edit, prevProps.edit)
-      || this.props.position === prevProps.position) {
+      && isEqual(this.props.edit, prevProps.edit)
+      && this.props.position === prevProps.position
+    ) {
       return false;
     }
 
@@ -118,6 +119,10 @@ class EditControl extends MapControl {
     this.leafletElement.remove(map);
     this.leafletElement = createDrawElement(this.props);
     this.leafletElement.addTo(map);
+
+    // Remount the new draw control
+    const { onMounted } = this.props;
+    onMounted && onMounted(this.leafletElement);
 
     return null;
   }

--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -105,7 +105,11 @@ class EditControl extends MapControl {
     // super updates positions if thats all that changed so call this first
     super.componentDidUpdate(prevProps);
 
-    if (isEqual(this.props.draw, prevProps.draw) || this.props.position !== prevProps.position) {
+    // If the props haven't changed, don't update
+    if (
+      isEqual(this.props.draw, prevProps.draw)
+      || isEqual(this.props.edit, prevProps.edit)
+      || this.props.position === prevProps.position) {
       return false;
     }
 


### PR DESCRIPTION
This fixes issue #69 

Changing the EditControl `edit` prop will now update the controls, which allows you to show/hide the edit/remove buttons