### PR TITLE
Use map from context when removing event handlers

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -54,8 +54,6 @@ function EditControl(props) {
     onMounted && onMounted(drawRef.current);
 
     return () => {
-      const { map } = props.leaflet;
-
       map.off(leaflet.Draw.Event.CREATED, onDrawCreate);
 
       for (const key in eventHandlers) {


### PR DESCRIPTION
When unmounting the map, it was trying to get the map from its leaflet prop, but that does not exist anymore.
The map from the context is already in scope and is used instead.

Fixes #103 

Easy to reproduce - unmount any map with the edit control.