### PR TITLE
bug(typings): Typing correction without in prop edit

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from 'react';
-import type { DrawOptions, EditOptions, ControlPosition } from 'leaflet';
-
+import type {
+  DrawOptions,
+  EditOptions,
+  ControlPosition,
+  EditPolyOptions,
+} from 'leaflet';
 
 interface EditControlProps {
   onEdited?: Function;
@@ -16,7 +20,7 @@ interface EditControlProps {
   onDeleteStart?: Function;
   onDeleteStop?: Function;
 
-  onCreated?: Function,
+  onCreated?: Function;
   onMounted?: Function;
   draw: {
     polyline?: DrawOptions.PolylineOptions | boolean;
@@ -25,10 +29,13 @@ interface EditControlProps {
     circle?: DrawOptions.CircleOptions | boolean;
     marker?: DrawOptions.MarkerOptions | boolean;
     circlemarker?: DrawOptions.CircleOptions | boolean;
-  },
+  };
+  edit: {
+    edit: EditPolyOptions.EditHandlerOptions | boolean;
+    remove?: EditPolyOptions.DeleteHandlerOptions | boolean;
+  };
 
-
-  position: ControlPosition,
+  position: ControlPosition;
 }
 
 export class EditControl extends React.Component<EditControlProps> {}


### PR DESCRIPTION


  ## Typing correction 
Using typescript, when trying to use the edit property in the EditControl component, I get the following error:

`
No overload matches this call.
  Overload 1 of 2, '(props: EditControlProps | Readonly<EditControlProps>): EditControl', gave the following error.
    Type '{ draw: { polygon: { shapeOptions: { color: string; weight: number; opacity: number; }; }; polyline: { shapeOptions: { color: string; weight: number; opacity: number; }; }; rectangle: boolean; marker: boolean; circlemarker: boolean; circle: boolean; }; ... 6 more ...; onDeleted: (layer: any) => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<EditControl> & Readonly<EditControlProps> & Readonly<...>'.
 Property 'edit' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<EditControl> & Readonly<EditControlProps> & Readonly<...>'.
  Overload 2 of 2, '(props: EditControlProps, context: any): EditControl', gave the following error.
    Type '{ draw: { polygon: { shapeOptions: { color: string; weight: number; opacity: number; }; }; polyline: { shapeOptions: { color: string; weight: number; opacity: number; }; }; rectangle: boolean; marker: boolean; circlemarker: boolean; circle: boolean; }; ... 6 more ...; onDeleted: (layer: any) => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<EditControl> & Readonly<EditControlProps> & Readonly<...>'.
      Property 'edit' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<EditControl> & Readonly<EditControlProps> & Readonly<...>'.ts(2769)
`

>  Which was easily fixed just by declaring the types in the index.d.ts file 





*Contribution*
**Cinthia Andrade**
