### PR TITLE
Allow react-leaflet 3.x in deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "leaflet-draw": "^1.0.3",
     "prop-types": "^15.5.2",
     "react": "^16.3.0 || ^17.0.0",
-    "react-leaflet": "^2.0.0"
+    "react-leaflet": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
The `package.json` previously limited this package to only work with react-leaflet 2.x, but after pretty thorough testing seems to operate with react-leaflet 3.x without any issues.

Would it be possible to get this merged so we can switch back to the main repo in our deps? If there's any known compatibility issues with react-leaflet 3 just let me know and I might be able to help issue a few updates.