### PR TITLE
Fix useEffect return

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -70,7 +70,7 @@ function EditControl(props) {
       isEqual(props.edit, propsRef.current.edit) &&
       props.position === propsRef.current.position
     ) {
-      return false;
+      return;
     }
     const { map } = context;
 
@@ -81,7 +81,7 @@ function EditControl(props) {
     const { onMounted } = props;
     onMounted && onMounted(drawRef.current);
 
-    return null;
+    return;
   }, [props.draw, props.edit, props.position]);
 
   return null;


### PR DESCRIPTION
React's useEffect should either return nothing or a valid clean up function.

When using React 1.8, `<EditContro l/>` crashes the app sometimes because, for one of the `useEffect` calls, it returns `false` and `null`.

This fixes the problem.

![Screenshot from 2022-04-28 13-40-37](https://user-images.githubusercontent.com/144458/165841977-231f40b8-e178-4725-a8d0-e9ef62b11eca.png)
