### PR TITLE
Update react-leaflet peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "leaflet-draw": "^1.0.3",
     "prop-types": "^15.5.2",
     "react": "^16.3.0 || ^17.0.0",
-    "react-leaflet": "^2.0.0"
+    "react-leaflet": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
## Description
Update react-leaflet peer dependency. Avoids requiring `--force` to install.

```
npm ERR! Could not resolve dependency:
npm ERR! peer react-leaflet@"^2.0.0" from react-leaflet-draw@0.19.8
npm ERR! node_modules/react-leaflet-draw
npm ERR!   react-leaflet-draw@"https://github.com/alex3165/react-leaflet-draw" from the root project
```

Related: https://github.com/alex3165/react-leaflet-draw/issues/87