### PR TITLE
respect prop changes for on[Delete/Update/Edited] callbacks

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -64,7 +64,7 @@ function EditControl(props) {
 
       drawRef.current.remove(map);
     };
-  }, []);
+  }, [props.onCreated, props.onDeleted, props.onEdited]);
 
   React.useEffect(() => {
     if (
@@ -86,7 +86,14 @@ function EditControl(props) {
     return () => {
       drawRef.current.remove(map);
     };
-  }, [props.draw, props.edit, props.position]);
+  }, [
+    props.draw, 
+    props.edit, 
+    props.position, 
+    props.onCreated,
+    props.onDeleted,
+    props.onEdited
+  ]);
 
   return null;
 }


### PR DESCRIPTION
`EditControl` silently makes `onDelete`, `onEdited` and `onCreated` immutable by passing the initial value to the Control Component, but not updating it when they change. 

This could lead (or it did in my project) to imcomprehensible problems.

By adding the callback properties to the `useEffect` function that creates the control, this is fixed.