### PR TITLE
bug: [#192] Fixed broken map event unmounting

### DIFF
--- a/src/EditControl.js
+++ b/src/EditControl.js
@@ -38,15 +38,9 @@ function EditControl(props) {
     const { onMounted } = props;
 
     for (const key in eventHandlers) {
-      map.on(eventHandlers[key], (evt) => {
-        let handlers = Object.keys(eventHandlers).filter(
-          (handler) => eventHandlers[handler] === evt.type
-        );
-        if (handlers.length === 1) {
-          let handler = handlers[0];
-          props[handler] && props[handler](evt);
-        }
-      });
+      if (props[key]) {
+        map.on(eventHandlers[key], props[key]);
+      }
     }
     map.on(leaflet.Draw.Event.CREATED, onDrawCreate);
     drawRef.current = createDrawElement(props, context);


### PR DESCRIPTION
Closes #192

To correctly unmount a event handler the `map.on()` and `map.off()` have to use the exact same props, otherwise the `map.off()` cannot correctly identify which handler to unmount, resulting in multiple (read duplicate) event handlers for the same event. See https://leafletjs.com/reference.html#evented-off for more information

By using a custom function on the `map.on()` (which in turn *might* call the correct `props[handler]`), the `props[handler]` is actually never used as event handler. Meaning that the `map.off()`, in the current setup, will never work.

By making sure that the `map.on()` and `map.off()` use the same function, the unmounting works as expected and old event handlers are removed.

I couldn't find a reason why this "function checking its own type, and then maybe calling the correct `props[handler]`" behaviour was implemented. If someone can tell me why (and preferably a bug report that shows an actual bug), i can look into a solution that uses the old setup.